### PR TITLE
Added support for configurable loop

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -19,6 +19,7 @@ window.Swipe = function(element, options) {
   this.speed = this.options.speed || 300;
   this.callback = this.options.callback || function() {};
   this.delay = this.options.auto || 0;
+  this.loop = this.options.loop || 'onlyNext';
 
   // reference dom elements
   this.container = element;
@@ -115,9 +116,12 @@ Swipe.prototype = {
     this.delay = delay || 0;
     clearTimeout(this.interval);
 
-    // if not at first slide
-    if (this.index) this.slide(this.index-1, this.speed);
-
+        // if not at first slide
+    if (this.index) {
+        this.slide(this.index-1, this.speed);
+    } else if (this.loop === 'onlyPrev' || this.loop === 'both') {
+        this.slide(this.length - 1, this.speed); //go to the last slide
+    }
   },
 
   next: function(delay) {
@@ -126,9 +130,11 @@ Swipe.prototype = {
     this.delay = delay || 0;
     clearTimeout(this.interval);
 
-    if (this.index < this.length - 1) this.slide(this.index+1, this.speed); // if not last slide
-    else this.slide(0, this.speed); //if last slide return to start
-
+    if (this.index < this.length - 1) {
+        this.slide(this.index+1, this.speed); // if not last slide
+    } else if (this.loop === 'onlyNext' || this.loop === 'both') {
+        this.slide(0, this.speed); //if last slide return to start
+    }
   },
 
   begin: function() {


### PR DESCRIPTION
Now you can pass option to the constructor:

```
loop: 'onlyNext|onlyPrev|both'
```

When `onlyNext` is set, slider will loop to the first slide when `next()` is invoked, otherwise it wont.
When `onlyPrev` is set, slider will loop to the last slide when `prev()` is invoked, otherwise it wont.
When 'both', that means both options below. 

Needed it in my project, so maybe someone else will benefit from this.
