### PR TITLE
Create an "isDisabled" flag + enable() and disable() functions to swipe.js

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -19,6 +19,7 @@ window.Swipe = function(element, options) {
   this.speed = this.options.speed || 300;
   this.callback = this.options.callback || function() {};
   this.delay = this.options.auto || 0;
+  this.isDisabled = false;
 
   // reference dom elements
   this.container = element;
@@ -106,6 +107,18 @@ Swipe.prototype = {
     this.index = index;
 
   },
+  
+  disable: function() {
+  
+		this.isDisabled = true;
+  
+  }
+  
+  enable: function() {
+  
+		this.isDisabled = false;
+  
+  }
 
   getPos: function() {
     
@@ -180,6 +193,10 @@ Swipe.prototype = {
   },
 
   onTouchStart: function(e) {
+  
+  	if (this.isDisabled) {
+  		return false;
+  	}
     
     this.start = {
 
@@ -204,6 +221,10 @@ Swipe.prototype = {
   },
 
   onTouchMove: function(e) {
+  
+  	if (this.isDisabled) {
+  		return false;
+  	}
 
     // ensure swiping with one touch and not pinching
     if(e.touches.length > 1 || e.scale && e.scale !== 1) return;
@@ -242,6 +263,10 @@ Swipe.prototype = {
   },
 
   onTouchEnd: function(e) {
+  
+  	if (this.isDisabled) {
+  		return false;
+  	}
 
     // determine if slide attempt triggers next/prev slide
     var isValidSlide = 


### PR DESCRIPTION
When writing for touch devices, occasionally you need to keep an eye on touch events that may overlap with each other. In one case, I wanted to have a pinch-to-zoom image overlayed on top of the swipe area. So I needed a way to temporarily disable swipe.js.

Please pardon the "debounced window resize" commits. They cancel eachother out (one is a revert from the other).
