### PR TITLE
 iOS6 Choppiness Fix

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -429,7 +429,7 @@ Swipe.prototype = {
     style.transitionDuration = speed + 'ms';
 
     // translate to given position
-    style.webkitTransform = 'translate3d(' + xval + 'px,0,0)';
+    style.webkitTransform = 'translate(' + xval + 'px,0)' + 'translateZ(0)';
     style.msTransform = 
     style.MozTransform = 
     style.OTransform = 'translateX(' + xval + 'px)';


### PR DESCRIPTION
Apple decided that translate3D would no longer automatically trigger hardware acceleration in iOS6. Replacing translate3D with translate in addition to translateZ(0) appears to correct this issue.
