### PR TITLE
Infinitely repeating slides

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Swipe can take an optional second parameter– an object of key/value settings:
 
 - **auto** Integer - begin with auto slideshow (time in milliseconds between slides)
 
+- **infinite** Boolean *(default:false)* - infinitely loops the slides, so that after the last slide you are on the first as if it was the next in line
+
 -	**callback** Function - runs at the end of any slide change. *(effective for updating position indicators/counters)*
 
 ### Example


### PR DESCRIPTION
This adds a flag to the options that when set to true will repeat the slides infinitely. This means that when scrolling if you are at the last slide and scroll for the next one it will display the first slide as if it was next in line. Similarly, if you are on the first slide and scroll for the prev slide it will display the last as if it was next in line.

Sadly, this adds a jquery dependency as it was the cleanest way to manipulate the DOM to add the duplicate data required to allow for the infinite scrolling to be seamless.

I completely understand an unwillingness to merge this request due to the added dependency, though I  feel like it is a decent start if someone wants to modify it so that it no longer required jQuery.

To demo take the existing index.html and add the jquery.js script and make sure to set `infinite:true` in the options in creation.
