### PR TITLE
Restore visibility attribute for slider element on completion of setup

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -67,6 +67,7 @@ Swipe.prototype = {
     if (!this.width) return null;
 
     // hide slider element but keep positioning during setup
+    var origVisibility = this.container.style.visibility;
     this.container.style.visibility = 'hidden';
 
     // dynamic css
@@ -82,8 +83,8 @@ Swipe.prototype = {
     // set start position and force translate to remove initial flickering
     this.slide(this.index, 0); 
 
-    // show slider element
-    this.container.style.visibility = 'visible';
+    // restore the visibility of the slider element
+    this.container.style.visibility = origVisibility;
 
   },
 


### PR DESCRIPTION
Added logic to restore the visibility attribute of the slider element, instead of previous logic which set it to 'visible'. This had the unwanted side effect of overriding inherited visibility settings or custom settings.
