### PR TITLE
Fixing text rendering issue in Chrome

### DIFF
--- a/style.css
+++ b/style.css
@@ -35,6 +35,8 @@ a {
 }
 .swipe {
   padding-bottom:20px;
+  position:relative;
+  z-index:1;
 }
 .swipe li div, .swipe div div div {
   margin:0 10px;


### PR DESCRIPTION
Adding position relative and specifying z-index to slider element solves text rendering bug in Chrome. More info and example from Jake Archibald here https://www.youtube.com/watch?v=9Woaz-cKPCE&hd=1
