### PR TITLE
Added goTo() method

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -160,6 +160,12 @@ Swipe.prototype = {
     this.begin();
   },
 
+  goTo: function(index, duration) {
+    this.delay = 0;
+    clearTimeout(this.interval);
+  	this.slide(index, duration);
+	},
+
   handleEvent: function(e) {
     switch (e.type) {
       case 'touchstart': this.onTouchStart(e); break;


### PR DESCRIPTION
Right now if you use slide() to go to a slide, and are using "auto," the interval isn't cleared. The goTo method will take you to the desired slide, and clear the auto slide show.
