### PR TITLE
Fallback for width property

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -66,7 +66,7 @@ Swipe.prototype = {
 
     // Fix width for Android WebView (i.e. PhoneGap) 
     if (this.width === 0 && typeof window.getComputedStyle === 'function') {
-      this.width = window.getComputedStyle(this.container, null).width;
+      this.width = window.getComputedStyle(this.container, null).width.replace('px','');
     }
 
     // return immediately if measurement fails


### PR DESCRIPTION
If used in Android 4.0.4 on top of PhoneGap 2.2.0, only the first image will be shown. The reason for this is that this.width is calculated to be 0. Using getComputedStyle avoids solves issue. This was the case when the container was placed within a hidden element, the same thing was observed in Firefox.
