### PR TITLE
iOS hardware acceleration trigger fix (CSS)

### DIFF
--- a/style.css
+++ b/style.css
@@ -37,6 +37,8 @@ a {
   padding-bottom:20px;
   position:relative;
   z-index:1;
+  -webkit-perspective: 1000;
+  -webkit-backface-visibility: hidden;
 }
 .swipe li div, .swipe div div div {
   margin:0 10px;


### PR DESCRIPTION
Addition of -webkit-perspective and -webkit-backface-visibility on container element in order to trigger hardware acceleration in iOS6.  This is a fix since translate3d no longer triggers hardware acceleration in iOS6 Safari.
