### PR TITLE
Add fix for Opera 12 (and above)

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -218,7 +218,8 @@ Swipe.prototype = {
       case 'touchend': this.onTouchEnd(e); break;
       case 'webkitTransitionEnd':
       case 'msTransitionEnd':
-      case 'oTransitionEnd':
+      case 'oTransitionEnd': // opera 11 and below
+      case 'otransitionend': // opera 12 (and above?)
       case 'transitionend': this.onTransitionEnd(e); break;
       case 'resize': this.setup(); break;
     }


### PR DESCRIPTION
Simply added a `case "otransitionend":` line to the `handleEvent` method to make it work in the latest Opera. Looks like they changed the `event.type` string to lowercase in Opera 12 :)
