### PR TITLE
Transitionless browsers now follow startSlide

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -123,6 +123,9 @@ Swipe.prototype = {
       this._stack(refArray[1],0);
       this._stack(refArray[2],1);
 
+    } else {
+      // move "viewport" to put current slide into view
+      this.element.style.left = (this.index * -this.width)+"px";
     }
 
     this.container.style.visibility = 'visible';


### PR DESCRIPTION
Fixes #155.

As an aside, this also fixes a bug I was having where resizing the IE window caused the viewport to no longer line up with the current slide, making the content "run away".
