### PR TITLE
transitionless browsers now call transitionEnd

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -459,13 +459,10 @@ Swipe.prototype = {
 
             elem.style.left = to + 'px';  // callback after this line
 
-            if (_this._getElemIndex(elem) == _this.index) { // only call transition end on the main slide item
+            if (_this.delay) _this.begin();
+          
+            _this.transitionEnd(_this.index, _this.slides[_this.index]);
 
-              if (_this.delay) _this.begin();
-            
-              _this.transitionEnd(_this.index, _this.slides[_this.index]);
-
-            }
 
             clearInterval(timer);
 


### PR DESCRIPTION
There was a logic error in the _animate function where it tested whether `elem` was the correct slide or not, however, `elem` is not a slide but the `swipe-wrap` element, so the test was never true.

This just removes that if() statement.
