### PR TITLE
Fix for issue #67 - use 2D transforms detection

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -24,7 +24,7 @@ window.Swipe = function(element, options) {
     })(),
     transitions: (function() {
       var temp = document.createElement('swipe'),
-          props = ['perspectiveProperty', 'WebkitPerspective', 'MozPerspective', 'OPerspective', 'msPerspective'];
+          props = ['transformProperty', 'WebkitTransform', 'MozTransform', 'OTransform', 'msTransform'];
       for ( var i in props ) {
         if (temp.style[ props[i] ] !== undefined) return true;
       }


### PR DESCRIPTION
I've tested this on the numerous browsers apart from Windows phone 8 and it works.
