### PR TITLE
Too wide table in slide breaks the swipe

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -82,6 +82,7 @@ Swipe.prototype = {
     while (index--) {
       var el = this.slides[index];
       el.style.width = this.width + 'px';
+      el.style.maxWidth = this.width + 'px';
       el.style.display = 'table-cell';
       el.style.verticalAlign = 'top';
     }


### PR DESCRIPTION
If the contents in the slides is too large to fit on the screen. ie on small phone screens with a slide containing a table that is too wide. The table then expands the li element and the offset of the slides goes bad. 
The fix is setting the max-width of the li element as well as the width. The content is still too big, and some of it will be hidden. But the swipe will work as intended.
