### PR TITLE
Enable / disable auto slideshow

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Swipe exposes a few functions that can be useful for script control of your slid
 
 `slide(index, duration)` slide to set index position (duration: speed of transition in milliseconds)
 
+`auto(time)` auto slideshow (time in milliseconds between slides - use 0 to disable auto slideshow)
+
 ## Browser Support
 Swipe is now compatable with all browsers, including IE7+. Swipe works best on devices that supports CSS transforms and touch, but can be used without these as well. A few helper methods determine touch and CSS transition support and choose the proper animation methods accordingly.
 

--- a/swipe.js
+++ b/swipe.js
@@ -422,6 +422,15 @@ function Swipe(container, options) {
       return index;
 
     },
+	auto: function(auto) {
+		
+		stop();
+		
+		delay = auto;
+		
+		// start auto slideshow if applicable
+		if (delay) begin();
+	},
     kill: function() {
 
       // cancel slideshow


### PR DESCRIPTION
Hi Brad,

we are already using the slideshow at www.terrafinanz.de. Because of our big images, we will only start autosliding after all images are loaded.

I added the functionality to enable auto sliding later and to disable auto sliding.

Can you please accept my pull request?

Here is my Code for enabling autosliding:
$( window ).load(function(){ 
    $( "#stage" ).data( "Swipe" ).auto(4000);
});

We have a separate control bar and hovering the control bar, we will stop auto sliding.
$( "#stage-control" ).on( "mouseenter", function() {
         $( "#stage" ).data( "Swipe" ).auto(0);
} );

Thank you very much and greetings from munich, germany, sebastian
