### PR TITLE
Allow slide() to set a slide duration of 0.

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -88,7 +88,7 @@ function Swipe(container, options) {
     // do nothing if already on requested slide
     if (index == to) return;
 
-    var slideDuration = (slideSpeed >= 0) ? slideSpeed : speed
+    var duration = (slideSpeed !== undefined) ? slideSpeed : speed;
     
     if (browser.transitions) {
 
@@ -97,12 +97,12 @@ function Swipe(container, options) {
 
       while (diff--) move((to > index ? to : index) - diff - 1, width * direction, 0);
 
-      move(index, width * direction, slideDuration);
-      move(to, 0, slideDuration);
+      move(index, width * direction, duration);
+      move(to, 0, duration);
 
     } else {
 
-      animate(index * -width, to * -width, slideDuration);
+      animate(index * -width, to * -width, duration);
 
     }
 


### PR DESCRIPTION
Slide() currently passes the default slide speed if slide is called with the speed parameter set to 0. This addresses the issue.
