### PR TITLE
added an option "circular"

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -140,6 +140,8 @@ function Swipe(container, options) {
       if (options.continuous) move(circle(to - direction), -(width * direction), 0); // we need to get the next in place
       
     } else {     
+      
+      to = circle(to);
       animate(index * -width, to * -width, slideSpeed || speed);
       //no fallback for a circular continuous if the browser does not accept transitions
     }


### PR DESCRIPTION
The circular option can be use for swiping always forward. When you reach the end, you go back to the first sliding in the same direction, so the slider seems endless.

I could not do this in the no transition fallback, though, because it would mean manipulating the dom (actually changing the order of the element in the list and recalculating indexes..).

Tell me what you think, if I need to change something, etc.
