### PR TITLE
Pause and resume methods in API

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -432,6 +432,19 @@ function Swipe(container, options) {
       // return total number of slides
       return slides.length;
     },
+    pause: function() {
+
+      // cancel slideshow
+      stop();
+
+    },
+    resume: function(){
+      
+      // resume slideshow
+      delay = options.auto || 0
+      interval = setTimeout(next, delay)
+
+    },
     kill: function() {
 
       // cancel slideshow


### PR DESCRIPTION
Since the easiest way to pause is to just stop the slideshow, I re-set the delay and re-start the slideshow from scratch for the resume. Might be a better way to do this but this approach seems to work fine.
