### PR TITLE
add childSelector option

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -37,7 +37,7 @@ function Swipe(container, options) {
   function setup() {
 
     // cache slides
-    slides = element.children;
+    slides = options.childSelector ? element.querySelectorAll(options.childSelector) : element.children;
     length = slides.length;
 
     // set continuous to false if only one slide


### PR DESCRIPTION
Ember.js adds script tags in between elements.

The childSelector option allows the swipes element children to be filtered using a selector.
