### PR TITLE
Made a new stacking context for swipe-wrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Also Swipe needs just a few styles added to your stylesheet:
 .swipe-wrap {
   overflow: hidden;
   position: relative;
+  z-index: 1;
 }
 .swipe-wrap > div {
   float:left;

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
 .swipe-wrap {
   overflow: hidden;
   position: relative;
+  z-index: 1;
 }
 .swipe-wrap > div {
   float:left;


### PR DESCRIPTION
Added z-index: 1 to .swipe-wrap selector which creates a new stacking
context. When the slider is animated, only it will be repainted.
It used to be that when the slider was repainted, all the other
positioned elements were repainted too.

Fixes #266.
