### PR TITLE
Fixing animation on IE9

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -19,7 +19,7 @@ function Swipe(container, options) {
     addEventListener: !!window.addEventListener,
     touch: ('ontouchstart' in window) || window.DocumentTouch && document instanceof DocumentTouch,
     transitions: (function(temp) {
-      var props = ['transitionProperty', 'WebkitTransition', 'MozTransition', 'OTransition', 'msTransition'];
+      var props = ['transitionProperty', 'WebkitTransition', 'MozTransition', 'OTransition', 'transition'];
       for ( var i in props ) if (temp.style[ props[i] ] !== undefined) return true;
       return false;
     })(document.createElement('swipe'))


### PR DESCRIPTION
This change fixes slide animation on IE9. While IE9 supports -ms-transform, it does not show actual animation, only the first and last position. This change makes IE9 use JS animation instead. IE10  understands `transition` so it will use CSS.

Tested on Chrome, Safari, IE10, Firefox, iOS 6 and Android 4.0.3 stock browser - all of them are using CSS transition. IE 8 and IE 9 use JavaScript.

Fixes the issue reported in #206
