### PR TITLE
Prevent existence of multiple auto advance intervals 

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -217,7 +217,7 @@ function Swipe(container, options) {
   var interval;
 
   function begin() {
-
+    clearTimeout(interval);
     interval = setTimeout(next, delay);
 
   }


### PR DESCRIPTION
When programmatically changing slides (via the exposed slide() method) on a slider created with an auto-advance option, multiple auto advance intervals can exist resulting in unexpected movements of the slider.
