### PR TITLE
consider using querySelector and querySelectorAll in setup() instead of ...

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -27,7 +27,11 @@ function Swipe(container, options) {
 
   // quit if no root element
   if (!container) return;
-  var element = container.children[0];
+  
+  // metamorph script tags in Ember totally throw off 'children[0]'
+  // var element = container.children[0];
+  var element = container.querySelector('.swipe-wrap');
+
   var slides, slidePos, width, length;
   options = options || {};
   var index = parseInt(options.startSlide, 10) || 0;
@@ -37,7 +41,9 @@ function Swipe(container, options) {
   function setup() {
 
     // cache slides
-    slides = element.children;
+    // metamorph script tags in Ember totally throw off 'children'
+    // slides = element.children;
+    slides = element.querySelectorAll(':not(script)');
     length = slides.length;
 
     // set continuous to false if only one slide


### PR DESCRIPTION
...children

EmberJS tosses in "metamorph" script tags everywhere as part of its binding magic, but that throws off the use of children[0] and children in lines 32 and 45 respectively (in setup()).

Using querySelector & querySelectorAll avoids the <script> tags.

Just thought I'd toss that your way :) Hope it's helpful!
