### PR TITLE
performance improvment

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -13,7 +13,6 @@ function Swipe(container, options) {
   // utilities
   var noop = function() {}; // simple no operation function
   var offloadFn = function(fn) { setTimeout(fn || noop, 0) }; // offload a functions execution
-  var jsLib = window.jQuery || window.Zepto;  // jQuery or Zepto 
   
   // check browser capabilities
   var browser = {
@@ -589,7 +588,7 @@ function Swipe(container, options) {
 
 }
 
-
+var jsLib = window.jQuery || window.Zepto;  // jQuery or Zepto 
 if ( jsLib ) {
   (function($) {
     $.fn.Swipe = function(params) {


### PR DESCRIPTION
Added a function to hide all slides and then show only current, next and prev. It prevents browser crash on iOS when there many slides and the slides are "heavy" (images, filters, styles, etc.). Should help with Issue #269.
