### PR TITLE
added "pause" and "resume" to swipe API

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -225,10 +225,17 @@ function Swipe(container, options) {
   function stop() {
 
     delay = 0;
-    clearTimeout(interval);
+    pause();
 
   }
 
+  function pause() {
+    clearTimeout(interval);
+  }
+
+  function resume() {
+    if (delay) begin();
+  }
 
   // setup initial vars
   var start = {};
@@ -547,6 +554,12 @@ function Swipe(container, options) {
 
       }
 
+    },
+    pause: function () {
+      pause();
+    },
+    resume: function () {
+      resume();
     }
   }
 


### PR DESCRIPTION
It's a little different from this pull request: https://github.com/bradbirdsall/Swipe/pull/253
In my pull request "pause" and "resume" really do pause and resume if the swipe is not stopped; they don't do anything if it's in stopped state.
In https://github.com/bradbirdsall/Swipe/pull/253 "resume" make a stopped swipe to slide again.
