### PR TITLE
Bower Package

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
 	"repository": {
 		
 		"type": "git",
-		"url": "git@github.com:bradbirdsall/Swipe.git"
+		"url": "git@github.com:chaoscod3r/Swipe.git"
 	},
 
 	"license": "MIT"


### PR DESCRIPTION
I have added a bower.json file to make this library available on bower packages and I have registered the repo as a package on bower under the name of `swipejs`.

**EDIT:** I've just found the package but under a different name : `Swipe` ; I thought that it should have the same name as the address `swipejs`, which would make it look like most of the other packages, starting with a lower case.
