### PR TITLE
Make automatically stopping the slideshow optional

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -36,7 +36,7 @@ function Swipe(container, options) {
   var speed = options.speed || 300;
   options.continuous = options.continuous !== undefined ? options.continuous : true;
 
-  var autoStop = options.autoStop || options.autoStop === undefined;
+  options.autoStop = options.autoStop || options.autoStop === undefined;
 
   function setup() {
 


### PR DESCRIPTION
In addition to pause/resume, this PR adds an option to prevent stopping the slideshow when the user hits next/prev or swipes. It defaults to the current behavior (stopping), but adding options.autoStop = false will make it reset the timer when the user hits next/prev or swipes instead of completely stopping. This includes pull request #308, thanks @robertoz-01.

I apologize for the noise caused by hinting.
