### PR TITLE
Add Mouse and IE10/Win8/WinPhone8 (MSPointer) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ Swipe can take an optional second parameter– an object of key/value settings:
 - **disableScroll** Boolean *(default:false)* - stop any touches on this container from scrolling the page
 
 - **stopPropagation** Boolean *(default:false)* - stop event propagation
- 
+
+- **preventClick** Boolean *(default:false)* - prevent a 'click' event from propagating off of the slide contents
+
 -	**callback** Function - runs at slide change.
 
 - **transitionEnd** Function - runs at the end slide transition.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Also Swipe needs just a few styles added to your stylesheet:
   visibility: hidden;
   position: relative;
   -ms-touch-action: pan-y; /* For IE10, to allow scrolling on swipe elements */
+  touch-action: pan-y; /* W3C spec style, to allow scrolling on swipe elements */
 }
 .swipe-wrap {
   overflow: hidden;

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Also Swipe needs just a few styles added to your stylesheet:
   overflow: hidden;
   visibility: hidden;
   position: relative;
+  -ms-touch-action: pan-y; /* For IE10, to allow scrolling on swipe elements */
 }
 .swipe-wrap {
   overflow: hidden;

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
   overflow: hidden;
   visibility: hidden;
   position: relative;
+  -ms-touch-action: pan-y;
 }
 .swipe-wrap {
   overflow: hidden;

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
   visibility: hidden;
   position: relative;
   -ms-touch-action: pan-y;
+  touch-action: pan-y;
 }
 .swipe-wrap {
   overflow: hidden;

--- a/swipe.js
+++ b/swipe.js
@@ -19,6 +19,7 @@ function Swipe(container, options) {
     addEventListener: !!window.addEventListener,
     touch: ('ontouchstart' in window) || window.DocumentTouch && document instanceof DocumentTouch,
     mstouch: window.navigator && window.navigator.msPointerEnabled,
+    pointer: window.navigator && window.navigator.pointerEnabled,
     transitions: (function(temp) {
       var props = ['transitionProperty', 'WebkitTransition', 'MozTransition', 'OTransition', 'msTransition'];
       for ( var i in props ) if (temp.style[ props[i] ] !== undefined) return true;
@@ -34,6 +35,11 @@ function Swipe(container, options) {
     evtStart = 'touchstart';
     evtMove = 'touchmove';
     evtStop = 'touchend';
+  }
+  else if (browser.pointer) {
+    evtStart = 'pointerdown';
+    evtMove = 'pointermove';
+    evtStop = 'pointerup';
   }
   else if (browser.mstouch) {
     evtStart = 'MSPointerDown';

--- a/swipe.js
+++ b/swipe.js
@@ -472,7 +472,7 @@ function Swipe(container, options) {
     
     // set touchstart event on element    
     element.addEventListener(evtStart, events, false);
-    element.addEventListener('click', events, false);
+    if (options.preventClick) element.addEventListener('click', events, false);
 
     if (browser.transitions) {
       element.addEventListener('webkitTransitionEnd', events, false);
@@ -559,7 +559,7 @@ function Swipe(container, options) {
 
         // remove current event listeners
         element.removeEventListener(evtStart, events, false);
-        element.removeEventListener('click', events, false);
+        if (options.preventClick) element.removeEventListener('click', events, false);
         element.removeEventListener('webkitTransitionEnd', events, false);
         element.removeEventListener('msTransitionEnd', events, false);
         element.removeEventListener('oTransitionEnd', events, false);


### PR DESCRIPTION
I found the existing MSPointer solutions to be a bit heavyweight, so here is my contribution to the project. A more streamlined approach to adding support for both mouse and MSPointer events.

The priority order for listening to events is (based on feature detection in the browser):
1) touch[start|move|end]
2) MSPointer[Down|Move|Up]
3) mouse[down|move|up]

The addition of -ms-touch-action is necessary in CSS to prevent the default scrolling behaviors; setting the value to 'pan-y' allows for you to still vertically scroll the page by tapping on the swipe element, while horizontal swiping will navigate through the slides as expected. If your carousel is arranged vertically, instead, you can adjust this value as appropriate for the desired behavior.

Furthermore, I suppress 'click' events on the swipe element (for mouse/MSPointer events). When swiping, I found the click event was firing, and propagating up the page causing undesired side effects (mostly with jQuery Mobile and a fixed header).

Hopefully you'll find this useful to merge. I also appreciate any feedback on how to improve upon these changes.
