### PR TITLE
Fix for 2 slide special case

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -31,6 +31,8 @@ function Swipe(container, options) {
   var slides, slidePos, width, length;
   options = options || {};
   var index = parseInt(options.startSlide, 10) || 0;
+  var position = index;
+  var clonedSlides = false;
   var speed = options.speed || 300;
   options.continuous = options.continuous !== undefined ? options.continuous : true;
 
@@ -48,6 +50,7 @@ function Swipe(container, options) {
       element.appendChild(slides[0].cloneNode(true));
       element.appendChild(element.children[1].cloneNode(true));
       slides = element.children;
+      clonedSlides = true;
     }
 
     // create an array to store current positions of each slide
@@ -147,7 +150,8 @@ function Swipe(container, options) {
     }
 
     index = to;
-    offloadFn(options.callback && options.callback(index, slides[index]));
+    position = clonedSlides ? (index % 2) : index;
+    offloadFn(options.callback && options.callback(position, slides[index]));
   }
 
   function move(index, dist, speed) {
@@ -199,7 +203,7 @@ function Swipe(container, options) {
 
         if (delay) begin();
 
-        options.transitionEnd && options.transitionEnd.call(event, index, slides[index]);
+        options.transitionEnd && options.transitionEnd.call(event, position, slides[index]);
 
         clearInterval(timer);
         return;
@@ -395,7 +399,8 @@ function Swipe(container, options) {
 
           }
 
-          options.callback && options.callback(index, slides[index]);
+          position = clonedSlides ? (index % 2) : index;
+          options.callback && options.callback(position, slides[index]);
 
         } else {
 
@@ -427,7 +432,7 @@ function Swipe(container, options) {
         
         if (delay) begin();
 
-        options.transitionEnd && options.transitionEnd.call(event, index, slides[index]);
+        options.transitionEnd && options.transitionEnd.call(event, position, slides[index]);
 
       }
 
@@ -499,7 +504,7 @@ function Swipe(container, options) {
     getPos: function() {
 
       // return current index position
-      return index;
+      return position;
 
     },
     getNumSlides: function() {


### PR DESCRIPTION
This addresses issue #278.

When there are only 2 slides, the actual slides are duplicated in order
to support continuous scrolling. This causes the actual indices passed
to callbacks to be 0..3, when the expected values are 0..1.

This change special-cases the 2 slide scenario and ensures the
externally visible values (callbacks, getPos()), are always within the
expected 0..1 range.

This is essentially a more complete version of the other fixes which
have been offered in other pull requests.
