### PR TITLE
added start and stop to API. Fixed issue #341: slideshow does not resume after touch event.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Swipe can take an optional second parameter– an object of key/value settings:
 
 - **startSlide** Integer *(default:0)* - index position Swipe should start at
 
--	**speed** Integer *(default:300)* - speed of prev and next transitions in milliseconds.
+- **speed** Integer *(default:300)* - speed of prev and next transitions in milliseconds.
 
 - **auto** Integer - begin with auto slideshow (time in milliseconds between slides)
 
@@ -54,7 +54,7 @@ Swipe can take an optional second parameter– an object of key/value settings:
 
 - **stopPropagation** Boolean *(default:false)* - stop event propagation
  
--	**callback** Function - runs at slide change.
+- **callback** Function - runs at slide change.
 
 - **transitionEnd** Function - runs at the end slide transition.
 
@@ -81,7 +81,7 @@ Swipe exposes a few functions that can be useful for script control of your slid
 
 `start()` starts the slideshow (auto mode)
 
-`stop()` stops the slideshow (auto mode)
+`stop()` stops the slideshow (auto mode). Using `next()` or `prev()` will not interrupt the paused state of the slideshow.
 
 `prev()` slide to prev
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ window.mySwipe = new Swipe(document.getElementById('slider'), {
 
 Swipe exposes a few functions that can be useful for script control of your slider.
 
+`start()` starts the slideshow (auto mode)
+
+`stop()` stops the slideshow (auto mode)
+
 `prev()` slide to prev
 
 `next()` slide to next

--- a/swipe.js
+++ b/swipe.js
@@ -13,6 +13,8 @@ function Swipe(container, options) {
   // utilities
   var noop = function() {}; // simple no operation function
   var offloadFn = function(fn) { setTimeout(fn || noop, 0) }; // offload a functions execution
+
+  var paused = false;
   
   // check browser capabilities
   var browser = {
@@ -197,7 +199,7 @@ function Swipe(container, options) {
 
         element.style.left = to + 'px';
 
-        if (delay) begin();
+        if (!paused && delay) begin();
 
         options.transitionEnd && options.transitionEnd.call(event, index, slides[index]);
 
@@ -425,7 +427,9 @@ function Swipe(container, options) {
 
       if (parseInt(event.target.getAttribute('data-index'), 10) == index) {
         
-        if (delay) begin();
+        delay = options.auto || 0;
+
+        if (!paused && delay) begin();
 
         options.transitionEnd && options.transitionEnd.call(event, index, slides[index]);
 
@@ -477,10 +481,14 @@ function Swipe(container, options) {
       // restore delay
       delay = options.auto || 0;
 
+      paused = false;
+
       begin();
 
     },
     stop: function() {
+
+      paused = true;
 
       stop();
 

--- a/swipe.js
+++ b/swipe.js
@@ -472,6 +472,19 @@ function Swipe(container, options) {
       setup();
 
     },
+    start: function() {
+
+      // restore delay
+      delay = options.auto || 0;
+
+      begin();
+
+    },
+    stop: function() {
+
+      stop();
+
+    },
     slide: function(to, speed) {
       
       // cancel slideshow


### PR DESCRIPTION
### `Start()` and `Stop()`

This allows easier manipulation from outside of the plugin.

For example, a pause on a hover event is now simple:
$('.swipe').hover(function() {
  $(this).data('Swipe').stop();
}, function() {
  $(this).data('Swipe').start();
});
### Slideshow Resume

Previously, the slideshow would no longer cycle automatically after touch interaction.

Added `paused` variable to maintain state from `stop()` API call

This should close issues #341, #322, #316, #242
