### PR TITLE
IE10 mobile 

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -34,7 +34,7 @@ function Swipe(container, options) {
   var index = parseInt(options.startSlide, 10) || 0;
   var speed = options.speed || 300;
   options.continuous = options.continuous !== undefined ? options.continuous : true;
-  if ( browser.pointer ) container.style.msTouchAction = 'pan-y';
+  if ( browser.pointer ) container.style.msTouchAction = 'none';
   function setup() {
 
     // cache slides

--- a/swipe.js
+++ b/swipe.js
@@ -228,24 +228,28 @@ function Swipe(container, options) {
     clearTimeout(interval);
 
   }
-  function preventDefault(e) {
-    e.preventDefault();
-  }
     
-  function toggleOffPreventClick() {
-    var links = element.getElementsByTagName("a");
-    for ( var i = 0 ; i < links.length ; i++) {
-      links[i].removeEventListener("click", preventDefault,false);
-    }
-  }
     
-  function toggleOnPreventClick() {
-    var links = element.getElementsByTagName("a");
-    for ( var i = 0 ; i < links.length ; i++) {
-      links[i].addEventListener("click", preventDefault, false);
-    }
-  }
-    
+    var linkHandler = {
+      
+      preventDefault: function (e) {
+        e.preventDefault();
+      },
+        
+      toggleOffPreventClick: function () {
+        var links = element.getElementsByTagName("a");
+        for ( var i = 0 ; i < links.length ; i++) {
+          links[i].removeEventListener("click", this.preventDefault,false);
+        }
+      },
+        
+      toggleOnPreventClick: function () {
+        var links = element.getElementsByTagName("a");
+        for ( var i = 0 ; i < links.length ; i++) {
+          links[i].addEventListener("click", this.preventDefault, false);
+        }
+      }
+    };
 
   // setup initial vars
   var start = {};
@@ -278,7 +282,7 @@ function Swipe(container, options) {
               // handles links inside the slider
               if( delta.x )
               {
-                  toggleOnPreventClick();
+                  linkHandler.toggleOnPreventClick();
               }
               
               break;
@@ -291,7 +295,7 @@ function Swipe(container, options) {
         case 'otransitionend':
         case 'transitionend':
               offloadFn(this.transitionEnd(event));
-              toggleOffPreventClick();
+              linkHandler.toggleOffPreventClick();
         break;
         case 'resize': offloadFn(setup.call()); break;
       }

--- a/swipe.js
+++ b/swipe.js
@@ -224,17 +224,33 @@ function Swipe(container, options) {
   }
 
   function stop() {
-
     delay = 0;
     clearTimeout(interval);
 
   }
-
+  function preventDefault(e) {
+    e.preventDefault();
+  }
+    
+  function toggleOffPreventClick() {
+    var links = element.getElementsByTagName("a");
+    for ( var i = 0 ; i < links.length ; i++) {
+      links[i].removeEventListener("click", preventDefault,false);
+    }
+  }
+    
+  function toggleOnPreventClick() {
+    var links = element.getElementsByTagName("a");
+    for ( var i = 0 ; i < links.length ; i++) {
+      links[i].addEventListener("click", preventDefault, false);
+    }
+  }
+    
 
   // setup initial vars
   var start = {};
   var delta = {};
-  var isScrolling;      
+  var isScrolling;
 
   // setup event capturing
   var events = {
@@ -257,7 +273,15 @@ function Swipe(container, options) {
         
         case 'MSPointerDown': this.start(event); break;
               
-        case 'MSPointerMove': this.move(event); break;
+        case 'MSPointerMove':
+              this.move(event);
+              // handles links inside the slider
+              if( delta.x )
+              {
+                  toggleOnPreventClick();
+              }
+              
+              break;
             
         case 'MSPointerUp': offloadFn(this.end(event)); break;
               
@@ -265,7 +289,10 @@ function Swipe(container, options) {
         case 'msTransitionEnd':
         case 'oTransitionEnd':
         case 'otransitionend':
-        case 'transitionend': offloadFn(this.transitionEnd(event)); break;
+        case 'transitionend':
+              offloadFn(this.transitionEnd(event));
+              toggleOffPreventClick();
+        break;
         case 'resize': offloadFn(setup.call()); break;
       }
 
@@ -306,7 +333,8 @@ function Swipe(container, options) {
           element.addEventListener('MSPointerUp', this, false);
       }
       
-        
+            
+      
         
 
     },
@@ -328,6 +356,9 @@ function Swipe(container, options) {
         x: pageX - start.x,
         y: pageY - start.y
       }
+        
+
+               
 
       // determine if scrolling test has run - one time test
       if ( typeof isScrolling == 'undefined') {
@@ -388,6 +419,14 @@ function Swipe(container, options) {
 
       if (options.continuous) isPastBounds = false;
       
+        
+                
+        
+       
+  
+        
+        
+        
       // determine direction of swipe (true:right, false:left)
       var direction = delta.x < 0;
 
@@ -461,6 +500,10 @@ function Swipe(container, options) {
       }
       
         
+        
+      
+        
+        
 
     },
     transitionEnd: function(event) {
@@ -470,7 +513,7 @@ function Swipe(container, options) {
         if (delay) begin();
 
         options.transitionEnd && options.transitionEnd.call(event, index, slides[index]);
-
+        
       }
 
     }


### PR DESCRIPTION
I've implemented the use of pointer for IE10 mobile.

This fixes a couple of issues already raised, but without preventing default links inside the slider, as well as using the clientX and clientY properties.

I've tested it on 
- Nokia Lumia 520 (Windows 8)
  -  Iphone 5 (iOS 6.1.4, Safari)
  -  Ipad 1 (iOS 5.1.1, Safari)
  -  Nexus 7 (Android 4.2.2, both Chrome and Firefox)
  -  LG-P500 (Android 2.2 vendor browser)
