### PR TITLE
Corrected functionality of getNumSlides

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -28,7 +28,7 @@ function Swipe(container, options) {
   // quit if no root element
   if (!container) return;
   var element = container.children[0];
-  var slides, slidePos, width, length;
+  var slides, actualAmountOfSlides, slidePos, width, length;
   options = options || {};
   var index = parseInt(options.startSlide, 10) || 0;
   var speed = options.speed || 300;
@@ -45,6 +45,7 @@ function Swipe(container, options) {
 
     //special case if two slides
     if (browser.transitions && options.continuous && slides.length < 3) {
+      actualAmountOfSlides = 2;
       element.appendChild(slides[0].cloneNode(true));
       element.appendChild(element.children[1].cloneNode(true));
       slides = element.children;
@@ -505,7 +506,7 @@ function Swipe(container, options) {
     getNumSlides: function() {
       
       // return total number of slides
-      return length;
+      return actualAmountOfSlides || length;
     },
     kill: function() {
 


### PR DESCRIPTION
getNumSlides now return the actual amount of slides when there are two slides and they get cloned to 4 slides.
