### PR TITLE
Add package.json and more concise/explicit dependency list

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,8 +21,7 @@ module.exports = function( grunt ) {
   });
 
   // build
-  grunt.loadNpmTasks('grunt-contrib');
+  grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.registerTask('build', 'uglify');
   grunt.registerTask('default', 'build');
-
 };

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "Swipe",
+  "version": "2.0.0",
+  "dependencies": {},
+  "devDependencies": {
+    "grunt": "~0.4.1",
+    "grunt-contrib-uglify": "~0.2.4"
+  },
+  "engines": {
+    "node": ">=0.8.0"
+  }
+}


### PR DESCRIPTION
- Add package.json so any developer can pull down project dependencies
  with just 'npm install'
- Remove dependency on grunt-contrib. It is enormous and all the project
  uses from it is grunt-contrib-uglify
