### PR TITLE
Add canSwipeTo function to optional parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Swipe can take an optional second parameter– an object of key/value settings:
 
 - **transitionEnd** Function - runs at the end slide transition.
 
+- **canSwipeTo** Function - runs prior to changing slide, returns a Boolean
+
 ### Example
 
 ``` js
@@ -70,7 +72,8 @@ window.mySwipe = new Swipe(document.getElementById('slider'), {
   disableScroll: false,
   stopPropagation: false,
   callback: function(index, elem) {},
-  transitionEnd: function(index, elem) {}
+  transitionEnd: function(index, elem) {},
+  canSwipeTo: function(index) {}
 });
 
 ```


### PR DESCRIPTION
Provide an option to test whether any individual slide change is valid.

The function is provided in as the 'canSwipeTo' key of the options object. And if provided is then run prior to any change in slide being made.

If the new slide is not valid to move to, then Swipe will follow the same behaviour as if it had reached the end of the slides.
## Example Use Case:

Swipe is being used to hold a calendar, where the user can swipe from month to month. At certain times the user should be able to swipe through the full set of months. At other points it may be desirable to restrict the range of months that can be seen.

The optional canSwipeTo test allows this condition to be implemented dynamically, without having to rebuild the Swipe object.
