### PR TITLE
Fixes issues where swipe containers are inside elements set to display: table-cell

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,9 @@
-<!DOCTYPE HTML> 
+<!DOCTYPE HTML>
 <html>
 <head>
 <title>Swipe 2</title>
 <meta http-equiv="X-UA-Compatible" content="IE=8">
-<meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0'/> 
+<meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0'/>
 <link href='style.css' rel='stylesheet'/>
 <style>
 
@@ -16,7 +16,7 @@
 }
 .swipe-wrap {
   overflow: hidden;
-  position: relative;
+  position: absolute;
 }
 .swipe-wrap > div {
   float:left;
@@ -64,8 +64,8 @@
 
 
 <div style='text-align:center;padding-top:20px;'>
-  
-  <button onclick='mySwipe.prev()'>prev</button> 
+
+  <button onclick='mySwipe.prev()'>prev</button>
   <button onclick='mySwipe.next()'>next</button>
 
 </div>

--- a/swipe.js
+++ b/swipe.js
@@ -13,7 +13,7 @@ function Swipe(container, options) {
   // utilities
   var noop = function() {}; // simple no operation function
   var offloadFn = function(fn) { setTimeout(fn || noop, 0) }; // offload a functions execution
-  
+
   // check browser capabilities
   var browser = {
     addEventListener: !!window.addEventListener,
@@ -82,6 +82,10 @@ function Swipe(container, options) {
 
     if (!browser.transitions) element.style.left = (index * -width) + 'px';
 
+    // set container height to height of contents
+    var contentHeight = element.getBoundingClientRect().height || element.offsetHeight;
+    container.style.height = contentHeight + 'px';
+
     container.style.visibility = 'visible';
 
   }
@@ -111,7 +115,7 @@ function Swipe(container, options) {
 
     // do nothing if already on requested slide
     if (index == to) return;
-    
+
     if (browser.transitions) {
 
       var direction = Math.abs(index-to) / (index-to); // 1: backward, -1: forward
@@ -131,16 +135,16 @@ function Swipe(container, options) {
 
       // move all the slides between index and to in the right direction
       while (diff--) move( circle((to > index ? to : index) - diff - 1), width * direction, 0);
-            
+
       to = circle(to);
 
       move(index, width * direction, slideSpeed || speed);
       move(to, 0, slideSpeed || speed);
 
       if (options.continuous) move(circle(to - direction), -(width * direction), 0); // we need to get the next in place
-      
-    } else {     
-      
+
+    } else {
+
       to = circle(to);
       animate(index * -width, to * -width, slideSpeed || speed);
       //no fallback for a circular continuous if the browser does not accept transitions
@@ -164,15 +168,15 @@ function Swipe(container, options) {
 
     if (!style) return;
 
-    style.webkitTransitionDuration = 
-    style.MozTransitionDuration = 
-    style.msTransitionDuration = 
-    style.OTransitionDuration = 
+    style.webkitTransitionDuration =
+    style.MozTransitionDuration =
+    style.msTransitionDuration =
+    style.OTransitionDuration =
     style.transitionDuration = speed + 'ms';
 
     style.webkitTransform = 'translate(' + dist + 'px,0)' + 'translateZ(0)';
-    style.msTransform = 
-    style.MozTransform = 
+    style.msTransform =
+    style.MozTransform =
     style.OTransform = 'translateX(' + dist + 'px)';
 
   }
@@ -186,13 +190,13 @@ function Swipe(container, options) {
       return;
 
     }
-    
+
     var start = +new Date;
-    
+
     var timer = setInterval(function() {
 
       var timeElap = +new Date - start;
-      
+
       if (timeElap > speed) {
 
         element.style.left = to + 'px';
@@ -233,7 +237,7 @@ function Swipe(container, options) {
   // setup initial vars
   var start = {};
   var delta = {};
-  var isScrolling;      
+  var isScrolling;
 
   // setup event capturing
   var events = {
@@ -270,7 +274,7 @@ function Swipe(container, options) {
         time: +new Date
 
       };
-      
+
       // used for testing first move event
       isScrolling = undefined;
 
@@ -305,7 +309,7 @@ function Swipe(container, options) {
       // if user is not trying to scroll vertically
       if (!isScrolling) {
 
-        // prevent native scrolling 
+        // prevent native scrolling
         event.preventDefault();
 
         // stop slideshow
@@ -320,15 +324,15 @@ function Swipe(container, options) {
 
         } else {
 
-          delta.x = 
-            delta.x / 
+          delta.x =
+            delta.x /
               ( (!index && delta.x > 0               // if first slide and sliding left
                 || index == slides.length - 1        // or if last slide and sliding right
                 && delta.x < 0                       // and if sliding at all
-              ) ?                      
+              ) ?
               ( Math.abs(delta.x) / width + 1 )      // determine resistance level
               : 1 );                                 // no resistance if false
-          
+
           // translate 1:1
           translate(index-1, delta.x + slidePos[index-1], 0);
           translate(index, delta.x + slidePos[index], 0);
@@ -344,18 +348,18 @@ function Swipe(container, options) {
       var duration = +new Date - start.time;
 
       // determine if slide attempt triggers next/prev slide
-      var isValidSlide = 
+      var isValidSlide =
             Number(duration) < 250               // if slide duration is less than 250ms
             && Math.abs(delta.x) > 20            // and if slide amt is greater than 20px
             || Math.abs(delta.x) > width/2;      // or if slide amt is greater than half the width
 
       // determine if slide attempt is past start and end
-      var isPastBounds = 
+      var isPastBounds =
             !index && delta.x > 0                            // if first slide and slide amt is greater than 0
             || index == slides.length - 1 && delta.x < 0;    // or if last slide and slide amt is less than 0
 
       if (options.continuous) isPastBounds = false;
-      
+
       // determine direction of swipe (true:right, false:left)
       var direction = delta.x < 0;
 
@@ -377,8 +381,8 @@ function Swipe(container, options) {
 
             move(index, slidePos[index]-width, speed);
             move(circle(index+1), slidePos[circle(index+1)]-width, speed);
-            index = circle(index+1);  
-                      
+            index = circle(index+1);
+
           } else {
             if (options.continuous) { // we need to get the next in this direction in place
 
@@ -424,7 +428,7 @@ function Swipe(container, options) {
     transitionEnd: function(event) {
 
       if (parseInt(event.target.getAttribute('data-index'), 10) == index) {
-        
+
         if (delay) begin();
 
         options.transitionEnd && options.transitionEnd.call(event, index, slides[index]);
@@ -444,8 +448,8 @@ function Swipe(container, options) {
 
   // add event listeners
   if (browser.addEventListener) {
-    
-    // set touchstart event on element    
+
+    // set touchstart event on element
     if (browser.touch) element.addEventListener('touchstart', events, false);
 
     if (browser.transitions) {
@@ -473,10 +477,10 @@ function Swipe(container, options) {
 
     },
     slide: function(to, speed) {
-      
+
       // cancel slideshow
       stop();
-      
+
       slide(to, speed);
 
     },
@@ -503,7 +507,7 @@ function Swipe(container, options) {
 
     },
     getNumSlides: function() {
-      
+
       // return total number of slides
       return length;
     },


### PR DESCRIPTION
Several of the popular CSS frameworks these days use display: table-cell for layout. table-cell elements will grow to contain their children, so having a hard set width caused the parent to grow to the full width of the swipe-wrap element.

Sorry for the white space changes. SublimeText2 does that automatically.
