### PR TITLE
[Felipe] Fix: gallery behaves wrong whenresizing slides in ios7 on rotation

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -249,7 +249,7 @@ function Swipe(container, options) {
         case 'oTransitionEnd':
         case 'otransitionend':
         case 'transitionend': offloadFn(this.transitionEnd(event)); break;
-        case 'resize': offloadFn(setup.call()); break;
+        case 'resize': offloadFn(setup); break;
       }
 
       if (options.stopPropagation) event.stopPropagation();


### PR DESCRIPTION
Images don't resize well on ipad/iphone on Rotation with ios7.
