### PR TITLE
Fixes disableScroll option on mobile

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -287,7 +287,11 @@ function Swipe(container, options) {
       // ensure swiping with one touch and not pinching
       if ( event.touches.length > 1 || event.scale && event.scale !== 1) return
 
-      if (options.disableScroll) event.preventDefault();
+      // bail out if opt is enabled and a move is detected
+      if (options.disableScroll) {
+        event.preventDefault();
+        return;
+      }
 
       var touches = event.touches[0];
 


### PR DESCRIPTION
I had some issues with the `disableScroll` option stopping touches on mobile (tested on iOS7). To fix this in my own app I used the following code. Perhaps i'm just using it wrong, but I couldn't get it to disable scrolling as is.

To replicate:  
Open this fiddle in Chrome with touch events enabled. Swipe left/right and the slider will cycle like normal, regardless of the option being true of false.
http://jsfiddle.net/H2rgR/2/

Working fiddle with code from PR branch:
http://jsfiddle.net/H2rgR/3/

BTW, thanks for the great work! This saved me a ton of time.
