### PR TITLE
swipe state with clickable slides WP8

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <title>Swipe 2</title>
-<meta http-equiv="X-UA-Compatible" content="IE=8">
+<meta http-equiv="X-UA-Compatible" content="IE=Edge">
 <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0'/> 
 <link href='style.css' rel='stylesheet'/>
 <style>

--- a/style.css
+++ b/style.css
@@ -6,7 +6,7 @@ html, body, div, span, object, iframe, h1, h2, h3, h4, h5, h6, p, del, dfn, em, 
   font-size:100%;
   vertical-align:baseline;
   background:transparent;
-  -ms-touch-action: none;
+  -ms-touch-action: pan-y;
 }
 body {
   -webkit-text-size-adjust:none;

--- a/style.css
+++ b/style.css
@@ -6,6 +6,7 @@ html, body, div, span, object, iframe, h1, h2, h3, h4, h5, h6, p, del, dfn, em, 
   font-size:100%;
   vertical-align:baseline;
   background:transparent;
+  -ms-touch-action: none;
 }
 body {
   -webkit-text-size-adjust:none;

--- a/swipe.js
+++ b/swipe.js
@@ -256,9 +256,8 @@ function Swipe(container, options) {
 
     },
     start: function(event) {
-      if (window.navigator.msPointerEnabled) {
-        var touches = event;
-      } else {
+      var touches = event;
+      if (!window.navigator.msPointerEnabled) {
         var touches = event.touches[0];
       }
 
@@ -292,9 +291,7 @@ function Swipe(container, options) {
     },
     move: function(event) {
       if (window.navigator.msPointerEnabled) {
-        if(!event.isPrimary) {
-            return;
-        }
+        if(!event.isPrimary) {return;}
         var touches = event;
       } else {
         // ensure swiping with one touch and not pinching
@@ -464,6 +461,7 @@ function Swipe(container, options) {
     // set touchstart event on element    
     if (browser.touch) element.addEventListener('touchstart', events, false);
     if (window.navigator.msPointerEnabled) element.addEventListener('MSPointerDown', events, false);
+    
     if (browser.transitions) {
       element.addEventListener('webkitTransitionEnd', events, false);
       element.addEventListener('msTransitionEnd', events, false);

--- a/swipe.js
+++ b/swipe.js
@@ -13,7 +13,7 @@ function Swipe(container, options) {
   // utilities
   var noop = function() {}; // simple no operation function
   var offloadFn = function(fn) { setTimeout(fn || noop, 0) }; // offload a functions execution
-  
+   var is_swiping=false;
   // check browser capabilities
   var browser = {
     addEventListener: !!window.addEventListener,
@@ -290,6 +290,7 @@ function Swipe(container, options) {
 
     },
     move: function(event) {
+    	is_swiping=true;
       if (window.navigator.msPointerEnabled) {
         if(!event.isPrimary) {return;}
         var touches = event;
@@ -443,9 +444,9 @@ function Swipe(container, options) {
         options.transitionEnd && options.transitionEnd.call(event, index, slides[index]);
 
       }
-
+			is_swiping=false;
     }
-
+		
   };
 
   // trigger setup
@@ -515,6 +516,10 @@ function Swipe(container, options) {
       // return current index position
       return index;
 
+    },
+    getState:function() {
+    	
+    	return is_swiping;
     },
     getNumSlides: function() {
       

--- a/swipe.js
+++ b/swipe.js
@@ -449,7 +449,7 @@ function Swipe(container, options) {
 
     }
 
-  }
+  };
 
   // trigger setup
   setup();

--- a/swipe.js
+++ b/swipe.js
@@ -241,9 +241,9 @@ function Swipe(container, options) {
     handleEvent: function(event) {
 
       switch (event.type) {
-        case 'touchstart': this.start(event); break;
-        case 'touchmove': this.move(event); break;
-        case 'touchend': offloadFn(this.end(event)); break;
+        case 'touchstart':case 'MSPointerDown': this.start(event); break;
+        case 'touchmove':case 'MSPointerMove': this.move(event); break;
+        case 'touchend': case 'MSPointerUp': offloadFn(this.end(event)); break;
         case 'webkitTransitionEnd':
         case 'msTransitionEnd':
         case 'oTransitionEnd':
@@ -256,8 +256,11 @@ function Swipe(container, options) {
 
     },
     start: function(event) {
-
-      var touches = event.touches[0];
+      if (window.navigator.msPointerEnabled) {
+        var touches = event;
+      } else {
+        var touches = event.touches[0];
+      }
 
       // measure start values
       start = {
@@ -278,18 +281,29 @@ function Swipe(container, options) {
       delta = {};
 
       // attach touchmove and touchend listeners
-      element.addEventListener('touchmove', this, false);
-      element.addEventListener('touchend', this, false);
+      if (window.navigator.msPointerEnabled) {
+        element.addEventListener("MSPointerMove", this, false);
+        element.addEventListener("MSPointerUp", this, false);
+      } else {
+        element.addEventListener('touchmove', this, false);
+        element.addEventListener('touchend', this, false);
+      }
 
     },
     move: function(event) {
+      if (window.navigator.msPointerEnabled) {
+        if(!event.isPrimary) {
+            return;
+        }
+        var touches = event;
+      } else {
+        // ensure swiping with one touch and not pinching
+        if ( event.touches.length > 1 || event.scale && event.scale !== 1) return;
+        var touches = event.touches[0];
+      }
 
-      // ensure swiping with one touch and not pinching
-      if ( event.touches.length > 1 || event.scale && event.scale !== 1) return
 
       if (options.disableScroll) event.preventDefault();
-
-      var touches = event.touches[0];
 
       // measure change in x and y
       delta = {
@@ -415,10 +429,12 @@ function Swipe(container, options) {
         }
 
       }
-
+    
       // kill touchmove and touchend event listeners until touchstart called again
-      element.removeEventListener('touchmove', events, false)
-      element.removeEventListener('touchend', events, false)
+      element.removeEventListener('touchmove', events, false);
+      element.removeEventListener('touchend', events, false);
+      element.removeEventListener("MSPointerMove", events, false);
+      element.removeEventListener("MSPointerUp", events, false);
 
     },
     transitionEnd: function(event) {
@@ -447,7 +463,7 @@ function Swipe(container, options) {
     
     // set touchstart event on element    
     if (browser.touch) element.addEventListener('touchstart', events, false);
-
+    if (window.navigator.msPointerEnabled) element.addEventListener('MSPointerDown', events, false);
     if (browser.transitions) {
       element.addEventListener('webkitTransitionEnd', events, false);
       element.addEventListener('msTransitionEnd', events, false);
@@ -538,6 +554,9 @@ function Swipe(container, options) {
         element.removeEventListener('oTransitionEnd', events, false);
         element.removeEventListener('otransitionend', events, false);
         element.removeEventListener('transitionend', events, false);
+        element.removeEventListener('MSPointerDown', events, false);
+        element.removeEventListener('MSPointerMove', events, false);
+        element.removeEventListener('MSPointerUp', events, false);
         window.removeEventListener('resize', events, false);
 
       }


### PR DESCRIPTION
added a boolean to keep track of the swipe state.
if your swipe able elemtents are clickable - the click would always be fired

with this addition the click can be intercepted like:

```
$("#my_elems").click(function() {
             //FIX FOR WP
             if(typeof(window.navigator.msPointerEnabled) != "undefined" && typeof(window.mySwipe.getState) == "function" && window.mySwipe.getState() == true) {
                       return;
              }


});
```

the following CSS is also usefull (atleast in my case :))

```
* {
-ms-touch-action: pan-y;
}
```
