### PR TITLE
stop() exposed.

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -496,6 +496,12 @@ function Swipe(container, options) {
       next();
 
     },
+    stop: function() {
+
+      // cancel slideshow
+      stop();
+
+    },
     getPos: function() {
 
       // return current index position


### PR DESCRIPTION
Expose the stop() function to halt the slideshow. Especially useful
before restarting, to cancel any setTimeouts in place. ~kjm~
