### PR TITLE
Fix argument error in <= IE9

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -12,7 +12,7 @@ function Swipe(container, options) {
 
   // utilities
   var noop = function() {}; // simple no operation function
-  var offloadFn = function(fn) { setTimeout(fn || noop, 0) }; // offload a functions execution
+  var offloadFn = function(fn) { if(typeof(fn) != "function") {fn = noop;} setTimeout(fn, 0) }; // offload a functions execution
 
   // check browser capabilities
   var browser = {


### PR DESCRIPTION
Was getting an argument error in <= IE9 until I change the call a bit to check for a function first.  Looked like fn was actually 'true' instead of a function on first call...  Weirdly enough I am not getting the same error on the swipejs home page but the slideshow doesn't actually finish going through all the slides, possibly another issue with <= IE9?  See attached.
![screen shot 2013-12-09 at 3 20 11 pm](https://f.cloud.github.com/assets/817344/1710049/5e7aacd8-6129-11e3-9702-71a3ed826ab3.png)
