### PR TITLE
Reset 'width' and 'left' style properties in kill()

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -519,16 +519,16 @@ function Swipe(container, options) {
       stop();
 
       // reset element
-      element.style.width = 'auto';
-      element.style.left = 0;
+      element.style.width = '';
+      element.style.left = '';
 
       // reset slides
       var pos = slides.length;
       while(pos--) {
 
         var slide = slides[pos];
-        slide.style.width = '100%';
-        slide.style.left = 0;
+        slide.style.width = '';
+        slide.style.left = '';
 
         if (browser.transitions) translate(pos, 0, 0);
 


### PR DESCRIPTION
In order to make use of values defined in CSS we need to clear values which were set by Swipe.
