### PR TITLE
Add an option to block swiping on the slider extremities

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Swipe can take an optional second parameter– an object of key/value settings:
 
 - **continuous** Boolean *(default:true)* - create an infinite feel with no endpoints
 
+- **blockInsteadOfResist** Boolean *(default:false)* - blocks swiping to the right on the first slide and swiping to the left on the last slide, continuous option must be set to false.
+
 - **disableScroll** Boolean *(default:false)* - stop any touches on this container from scrolling the page
 
 - **stopPropagation** Boolean *(default:false)* - stop event propagation
@@ -67,6 +69,7 @@ window.mySwipe = new Swipe(document.getElementById('slider'), {
   speed: 400,
   auto: 3000,
   continuous: true,
+  blockInsteadOfResist: false,
   disableScroll: false,
   stopPropagation: false,
   callback: function(index, elem) {},

--- a/swipe.js
+++ b/swipe.js
@@ -320,19 +320,28 @@ function Swipe(container, options) {
 
         } else {
 
-          delta.x =
-            delta.x /
-              ( (!index && delta.x > 0               // if first slide and sliding left
-                || index == slides.length - 1        // or if last slide and sliding right
-                && delta.x < 0                       // and if sliding at all
-              ) ?
-              ( Math.abs(delta.x) / width + 1 )      // determine resistance level
-              : 1 );                                 // no resistance if false
+          // if blockInsteadOfResist is true, block swiping to the right
+          // on the first slide and swiping to the left on the last slide
+          var shouldBlock =
+            (options.blockInsteadOfResist && (!index && delta.x > 0 || index == slides.length - 1))
+            ? true
+            : false;
 
-          // translate 1:1
-          translate(index-1, delta.x + slidePos[index-1], 0);
-          translate(index, delta.x + slidePos[index], 0);
-          translate(index+1, delta.x + slidePos[index+1], 0);
+          if(!shouldBlock) {
+            delta.x =
+              delta.x /
+                ( (!index && delta.x > 0               // if first slide and sliding left
+                  || index == slides.length - 1        // or if last slide and sliding right
+                  && delta.x < 0                       // and if sliding at all
+                ) ?
+                ( Math.abs(delta.x) / width + 1 )      // determine resistance level
+                : 1 );                                 // no resistance if false
+
+            // translate 1:1
+            translate(index-1, delta.x + slidePos[index-1], 0);
+            translate(index, delta.x + slidePos[index], 0);
+            translate(index+1, delta.x + slidePos[index+1], 0);
+          }
         }
 
       }


### PR DESCRIPTION
Added an option named `blockInsteadOfResist` (set to `false`by default) allowing to block swiping to the right on the first slide and swiping to the left on the last slide, instead of just making resistance. Of course, the `continuous` option must be set to `false`.
