### PR TITLE
Fix circular array index calculation (function circle)

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -103,7 +103,7 @@ function Swipe(container, options) {
   function circle(index) {
 
     // a simple positive modulo using slides.length
-    return (slides.length + (index % slides.length)) % slides.length;
+    return index % slides.length;
 
   }
 

--- a/swipe.js
+++ b/swipe.js
@@ -102,6 +102,12 @@ function Swipe(container, options) {
 
   function circle(index) {
 
+    // handle negative index
+    if (index < 0) {
+      while (index < 0) {
+        index += slides.length;
+      }
+    }
     // a simple positive modulo using slides.length
     return index % slides.length;
 


### PR DESCRIPTION
fix circle() bug. on slide 1, if user clicks on last slide it goes to the next slide rather than last slide.
