### PR TITLE
Ensure slide diff calculation is a number

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -28,7 +28,8 @@ function Swipe(container, options) {
   // quit if no root element
   if (!container) return;
   var element = container.children[0];
-  var slides, slidePos, width, length;
+  var slides, slidePos, width;
+  var length = element.children.length;
   options = options || {};
   var index = parseInt(options.startSlide, 10) || 0;
   var speed = options.speed || 300;
@@ -38,7 +39,6 @@ function Swipe(container, options) {
 
     // cache slides
     slides = element.children;
-    length = slides.length;
 
     // set continuous to false if only one slide
     if (slides.length < 2) options.continuous = false;


### PR DESCRIPTION
Updating the slide method to recalculate the "to" target as a number. Existing method had unexpected behavior when "to" was passed in as a string, as the + operator would concatenate, instead of adding.
