### PR TITLE
fix Array definition to literal

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -51,7 +51,7 @@ function Swipe(container, options) {
     }
 
     // create an array to store current positions of each slide
-    slidePos = new Array(slides.length);
+    slidePos = [];
 
     // determine width of each slide
     width = container.getBoundingClientRect().width || container.offsetWidth;


### PR DESCRIPTION
New Array is not safe . Array definition is safer to user [](literal type) than  new Array() 
because, you can override the value of Array in JavaScript 
ex:) 
Array = function(){ 
    alert("test" ); 
};
slidePos = new Array( 3 ); 
slide Pos is alert("test");
