### PR TITLE
Implement getCurrIndex function

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -508,6 +508,17 @@ function Swipe(container, options) {
       return index;
 
     },
+    getCurrIndex: function() {
+      // Fix for the clone issue in the event of 2 slides
+      var current_index = this.getPos();
+      var number_of_slides = this.getNumSlides();
+    
+      if (current_index >= number_of_slides) {
+        current_index = current_index - number_of_slides;
+      }
+    
+      return current_index;
+    },
     getNumSlides: function() {
 
       // return total number of slides


### PR DESCRIPTION
Implements a fix for Issue #443.

The `getPos()` function is meant to return the zero index of the swipe object however in the event that the swipe object has only 2 elements, the cloning functionality results in a false index value.

The `getCurrIndex()` function is intended as a replacement that resolves this issue.
