### PR TITLE
Add Handling Mouse Events for PC Browsers

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -567,7 +567,7 @@ function Swipe(container, options) {
       if (browser.addEventListener) {
 
         // remove current event listeners
-        element.removeEventListener(bowser.touchstart, events, false);
+        element.removeEventListener(browser.touchstart, events, false);
         element.removeEventListener('webkitTransitionEnd', events, false);
         element.removeEventListener('msTransitionEnd', events, false);
         element.removeEventListener('oTransitionEnd', events, false);


### PR DESCRIPTION
### Add Handling Mouse Events for PC Browsers
- IE 10+ 
- In IE9, Swiping with Mouse events isn't supported like now. Because IE9 doesn't support addEventListener.
